### PR TITLE
Possibility to only update a folder and not entering another one

### DIFF
--- a/lib/xbmcswift/plugin.py
+++ b/lib/xbmcswift/plugin.py
@@ -190,7 +190,8 @@ class Plugin(object):
         #return li
         return options['url'], li, options.get('is_folder', True)
 
-    def add_items(self, iterable):
+    def add_items(self, iterable, is_update=False):
+        # Set is_update to True if this is only an update and not a subfolder, useful for paginations
         # If we are in debug mode, do not make the call to xbmc
         # for each item
         #   if in debug mode, print it to command line
@@ -217,7 +218,7 @@ class Plugin(object):
         if self._mode is 'xbmc':
             if not xbmcplugin.addDirectoryItems(self.handle, items, len(items)):
                 raise Exception, 'problem?'
-            xbmcplugin.endOfDirectory(self.handle)
+            xbmcplugin.endOfDirectory(self.handle, updateListing=is_update)
 
         return urls
 


### PR DESCRIPTION
Commit:
added possibility to only update a folder and not entering another one (subfolder)

This is very useful for paginations.
Example:
If you are in page 3 (which you entered through page 1 and 2) and you go one folder up (through "..") you are going to the real parent (categories for example) and not page 2.
