### PR TITLE
add possibility to set the view_mode via "plugin.add_items(items, view_mode)"

### DIFF
--- a/lib/xbmcswift/plugin.py
+++ b/lib/xbmcswift/plugin.py
@@ -190,7 +190,7 @@ class Plugin(object):
         #return li
         return options['url'], li, options.get('is_folder', True)
 
-    def add_items(self, iterable):
+    def add_items(self, iterable, view_mode=None):
         # If we are in debug mode, do not make the call to xbmc
         # for each item
         #   if in debug mode, print it to command line
@@ -217,6 +217,8 @@ class Plugin(object):
         if self._mode is 'xbmc':
             if not xbmcplugin.addDirectoryItems(self.handle, items, len(items)):
                 raise Exception, 'problem?'
+            if view_mode:
+                xbmc.executebuiltin('Container.SetViewMode(%s)' % view_mode)
             xbmcplugin.endOfDirectory(self.handle)
 
         return urls


### PR DESCRIPTION
added possibility to set the view_mode via "plugin.add_items(items, view_mode)"

Can be used to set the folder listing to a given view by its id. video_mode=500 is thumbnail view.
This is just an example - feel free to refuse or implement in a different way.
