### PR TITLE
Avoid too many values to unpack error

### DIFF
--- a/lib/xbmcswift/plugin.py
+++ b/lib/xbmcswift/plugin.py
@@ -35,7 +35,7 @@ class Plugin(object):
         if self._mode in debug_modes:
             self._plugin._setup(os.path.dirname(self._filepath))
 
-        self._argv0, self._argv1, self._argv2 = args
+        self._argv0, self._argv1, self._argv2, resume = args
         self.handle = int(self._argv1)
 
         self.qs_args = parse_qs(self._argv2.lstrip('?'))


### PR DESCRIPTION
I just installed the EyeTV-parser plugin (which depends on this plugin) to see what it can do with my EyeTV Hybrid before I decide what hardware/software to buy for OTA TV. The EyeTV-parser add-on would not launch and the log showed a trace for an error coming from this line (38) saying there were too many values to unpack, so I printed the args to debug and it contained 4 values, the last being 'resume:false'. Supplying the dummy value allowed the plugin to load.  There are of course other issues, but this was a nice/simple un-blocking work-around/fix.